### PR TITLE
Improve calculation of progress percentage

### DIFF
--- a/calculate.py
+++ b/calculate.py
@@ -8,6 +8,7 @@ def calculate_distance(x1, y1, z1, x2, y2, z2):
 
 # Calculate distance from current system to destination system
 # As a percentage of the distance from origin system to destination system
-def calculate_percentage(ori_to_dest, curr_to_dest, decimal_places=2):
-    invert_curr_to_dest = ori_to_dest - curr_to_dest
-    return round(invert_curr_to_dest / ori_to_dest * 100, decimal_places)
+def calculate_percentage(ori_to_curr, curr_to_dest, decimal_places=2):
+    dist = ori_to_curr + curr_to_dest
+    invert_curr_to_dest = dist - curr_to_dest
+    return round(invert_curr_to_dest / dist * 100, decimal_places)

--- a/standalone.py
+++ b/standalone.py
@@ -19,17 +19,17 @@ current.setName(name=get_system_name("Enter the name of the system you are curre
 origin_coords = origin.getCoords()
 destination_coords = destination.getCoords()
 current_coords = current.getCoords()
-ori_to_dest_distance = calculate.calculate_distance(origin_coords["x"],
+ori_to_curr_distance = calculate.calculate_distance(origin_coords["x"],
                                                     origin_coords["y"],
                                                     origin_coords["z"],
-                                                    destination_coords["x"],
-                                                    destination_coords["y"],
-                                                    destination_coords["z"])
+                                                    current_coords["x"],
+                                                    current_coords["y"],
+                                                    current_coords["z"])
 curr_to_dest_distance = calculate.calculate_distance(current_coords["x"],
                                                      current_coords["y"],
                                                      current_coords["z"],
                                                      destination_coords["x"],
                                                      destination_coords["y"],
                                                      destination_coords["z"])
-percentage = calculate.calculate_percentage(ori_to_dest_distance,curr_to_dest_distance)
+percentage = calculate.calculate_percentage(ori_to_curr_distance, curr_to_dest_distance)
 print("You are " + str(percentage) + "% of the way there!")


### PR DESCRIPTION
Instead of assuming the total distance is the distance from _origin to destination_, we instead use the sum of the distance from _origin to current_ and _current to destination_ as the total distance. This improves accuracy of calculation for if the current system does not lie exactly on the origin to destination line.