### PR TITLE
Clear origin and destination systems functionality

### DIFF
--- a/edsm.py
+++ b/edsm.py
@@ -20,7 +20,7 @@ def get_coords_from_edsm(system_name):
         url = urlopen(edsm_url, timeout=15)
         response = url.read()
         edsm_json = json.loads(response)
-        if "name" and "coords" in edsm_json:
+        if {"name", "coords"} <= edsm_json.keys():
             success = True
             x = edsm_json["coords"]["x"]
             y = edsm_json["coords"]["y"]

--- a/edsm.py
+++ b/edsm.py
@@ -12,6 +12,10 @@ except ModuleNotFoundError:
 def get_coords_from_edsm(system_name):
     system_name_url = quote(system_name)
     edsm_url = "https://www.edsm.net/api-v1/system?systemName={SYSTEM}&showCoordinates=1".format(SYSTEM=system_name_url)
+    success = False
+    x = 0
+    y = 0
+    z = 0
     try:
         url = urlopen(edsm_url, timeout=15)
         response = url.read()
@@ -22,13 +26,7 @@ def get_coords_from_edsm(system_name):
             y = edsm_json["coords"]["y"]
             z = edsm_json["coords"]["z"]
         else:
-            success = False
-            x = 0
-            y = 0
-            z = 0
+            pass
     except IOError:
-        success = False
-        x = 0
-        y = 0
-        z = 0
+        pass
     return success, x, y, z

--- a/edsm.py
+++ b/edsm.py
@@ -20,7 +20,7 @@ def get_coords_from_edsm(system_name):
         url = urlopen(edsm_url, timeout=15)
         response = url.read()
         edsm_json = json.loads(response)
-        if {"name", "coords"} <= edsm_json.keys():
+        if "name" and "coords" in edsm_json:
             success = True
             x = edsm_json["coords"]["x"]
             y = edsm_json["coords"]["y"]

--- a/edsm.py
+++ b/edsm.py
@@ -26,7 +26,7 @@ def get_coords_from_edsm(system_name):
             x = 0
             y = 0
             z = 0
-    except:
+    except IOError:
         success = False
         x = 0
         y = 0

--- a/load.py
+++ b/load.py
@@ -93,7 +93,7 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
         update_progress()
 
 
-def update_systems():
+def update_systems(ui_update=False):
     log("Updating origin and destination systems...")
     origin_name = config.get("ExProg_OriginSystem")
     destination_name = config.get("ExProg_DestinationSystem")
@@ -101,8 +101,9 @@ def update_systems():
     origin.setName(name=origin_name, verify=True, populate=True)
     destination.setName(name=destination_name, verify=True, populate=True)
     log("Origin and destination systems updated")
-    update_status()
-    update_progress()
+    if ui_update:
+        update_status()
+        update_progress()
 
 
 def update_progress():

--- a/load.py
+++ b/load.py
@@ -92,10 +92,12 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
         update_status()
         update_progress()
         if current.getName() == destination.getName():
+            log("Destination reached")
             # Reached destination
             config.set("ExProg_OriginSystem", None)
             config.set("ExProg_DestinationSystem", None)
             update_systems(ui_update=False)
+            update_status("destination_reached")
 
 
 def update_systems(ui_update=False):
@@ -141,7 +143,7 @@ def update_progress():
     log("Progress updated")
 
 
-def update_status():
+def update_status(external_message=None):
     log("Updating status...")
     status_message = ""
     status_colour = ""
@@ -171,6 +173,11 @@ def update_status():
                          "Either log into the game or\n" \
                          "make a hyperspace jump to find your current location."
         status_colour = "yellow"
+    elif external_message == "destination_reached":
+        log("Destination reached")
+        status_message = "You made it to\n" \
+                         "your destination!"
+        status_colour = "green"
     else:
         log("All systems go!")
         status_message = ""

--- a/load.py
+++ b/load.py
@@ -147,7 +147,12 @@ def update_status(external_message=None):
     log("Updating status...")
     status_message = ""
     status_colour = ""
-    if not origin.getNameSet():
+    if external_message == "destination_reached":
+        log("Destination reached")
+        status_message = "You made it to\n" \
+                         "your destination!"
+        status_colour = "green"
+    elif not origin.getNameSet():
         log("Origin system not set")
         status_message = "The origin system hasn't been specified.\n" \
                          "Set it in the Exploration Progress tab in File -> Settings."
@@ -173,11 +178,6 @@ def update_status(external_message=None):
                          "Either log into the game or\n" \
                          "make a hyperspace jump to find your current location."
         status_colour = "yellow"
-    elif external_message == "destination_reached":
-        log("Destination reached")
-        status_message = "You made it to\n" \
-                         "your destination!"
-        status_colour = "green"
     else:
         log("All systems go!")
         status_message = ""

--- a/load.py
+++ b/load.py
@@ -94,8 +94,8 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
         if current.getName() == destination.getName():
             log("Destination reached")
             # Reached destination
-            config.set("ExProg_OriginSystem", None)
-            config.set("ExProg_DestinationSystem", None)
+            config.set("ExProg_OriginSystem", "")
+            config.set("ExProg_DestinationSystem", "")
             update_systems(ui_update=False)
             update_status("destination_reached")
 

--- a/load.py
+++ b/load.py
@@ -25,7 +25,7 @@ origin = System()
 destination = System()
 current = System()
 
-version = "1.0.1"
+version = "1.0.2-indev"
 
 def plugin_start():
     # Load plugin into EDMC

--- a/load.py
+++ b/load.py
@@ -91,6 +91,11 @@ def journal_entry(cmdr, is_beta, system, station, entry, state):
         log("Updated current system")
         update_status()
         update_progress()
+        if current.getName() == destination.getName():
+            # Reached destination
+            config.set("ExProg_OriginSystem", None)
+            config.set("ExProg_DestinationSystem", None)
+            update_systems(ui_update=False)
 
 
 def update_systems(ui_update=False):


### PR DESCRIPTION
Sets the origin and destination system values to blank when the player's current system name matches the destination system. Also provides a status message when this happens. Resolves #7.