### PR TITLE
Use requests instead of urlopen to fetch edsm coordinates

### DIFF
--- a/edsm.py
+++ b/edsm.py
@@ -1,21 +1,19 @@
-import json
+import requests
+
 try:
     # Python 2
-    from urllib2 import quote, urlopen
+    from urllib2 import quote
 except ModuleNotFoundError:
     # Python 3
     from urllib.parse import quote
-    from urllib.request import urlopen
-
 
 # Use the Elite Dangerous Star Map API to get system coordinates
 def get_coords_from_edsm(system_name):
     system_name_url = quote(system_name)
     edsm_url = "https://www.edsm.net/api-v1/system?systemName={SYSTEM}&showCoordinates=1".format(SYSTEM=system_name_url)
     try:
-        url = urlopen(edsm_url, timeout=15)
-        response = url.read()
-        edsm_json = json.loads(response)
+        response = requests.get(edsm_url, timeout=15)
+        edsm_json = response.json() 
         if "name" and "coords" in edsm_json:
             success = True
             x = edsm_json["coords"]["x"]


### PR DESCRIPTION
This is to address issue #20 

I was able to reproduce on my system and found that it was caused by failed ssl certificate verification. Here's a snippet from EDMarketConnector.log with the exception thrown in edsm.py:

```
2021-11-20 17:06:05.008 - DEBUG - 9504:4700:4700 <plugins>.exploration-progress.load.update_systems:140: Origin system: Cubeo, Destination system: Colonia
<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1129)>
```

A similar issue is discussed in the main EDMC branch: https://github.com/EDCD/EDMarketConnector/issues/1288